### PR TITLE
fix: split release test workflow steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,14 @@ jobs:
       - name: Build application
         run: bun run build
 
-      - name: Run full test suite
-        run: bun run test:all
+      - name: Run unit tests
+        run: bun run test
+
+      - name: Run integration tests
+        run: bun run test:integration
+
+      - name: Run backend e2e tests
+        run: bun run test:e2e
 
       - name: Fetch latest tag
         id: latest-tag


### PR DESCRIPTION
## Summary
- replace the monolithic release test step with the same split test sequence already used by CI
- avoid the timeout pattern seen in the merged release workflow while keeping the release versioning flow unchanged
- keep build, integration, and backend e2e coverage in the release job

## Test Plan
- npm ci --ignore-scripts
- bun run build
- bun run test
- bun run test:integration
- bun run test:e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow testing process by organizing tests into separate, dedicated steps for unit, integration, and backend end-to-end testing. This improves testing visibility and ensures more comprehensive validation before each release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->