### PR TITLE
fix: set release tag identity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
         if: ${{ steps.bump.outputs.value != 'none' }}
         env:
           NEXT_VERSION: ${{ steps.next-version.outputs.value }}
-        run: git tag -a "v${NEXT_VERSION}" -m "Release v${NEXT_VERSION}"
+        run: git -c user.name='github-actions[bot]' -c user.email='41898282+github-actions[bot]@users.noreply.github.com' tag -a "v${NEXT_VERSION}" -m "Release v${NEXT_VERSION}"
 
       - name: Push release commit and tag
         if: ${{ steps.bump.outputs.value != 'none' }}


### PR DESCRIPTION
## Summary
- set an explicit git identity for the annotated release tag step
- keep the split release test flow from PR #30 unchanged
- unblock the post-test release tag creation on main

## Test Plan
- npm ci --ignore-scripts
- bun run build
- bun run test
- bun run test:integration
- bun run test:e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release testing workflow with enhanced test execution and configuration for more reliable deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->